### PR TITLE
fix: Ensure object-alt runs correctly

### DIFF
--- a/reports/axe-core-mapping.json
+++ b/reports/axe-core-mapping.json
@@ -3,8 +3,8 @@
   "name": "Axe-core",
   "version": "latest",
   "approvedRules": {
-    "complete": 18,
-    "partial": 3,
+    "complete": 19,
+    "partial": 2,
     "minimal": 0,
     "inconsistent": 1,
     "untested": 0
@@ -5823,7 +5823,7 @@
       "procedureNames": [
         "object-alt"
       ],
-      "consistency": "partial",
+      "consistency": "complete",
       "accessibilityRequirements": {
         "correct": true,
         "expected": [
@@ -5834,7 +5834,7 @@
         ]
       },
       "coverage": {
-        "covered": 17,
+        "covered": 18,
         "untested": 0,
         "cantTell": 0,
         "testCaseTotal": 18
@@ -5970,7 +5970,7 @@
             {
               "procedureName": "object-alt",
               "outcomes": [
-                "inapplicable"
+                "failed"
               ]
             }
           ]

--- a/reports/axe-core.json
+++ b/reports/axe-core.json
@@ -11126,7 +11126,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/2c4e13b6606b88bbe10bfffbe4b6f4e6d373c4a7.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/2c4e13b6606b88bbe10bfffbe4b6f4e6d373c4a7.html"
       },
       "assertedBy": "https://github.com/dequelabs/axe-core/releases/tag/4.4.3-canary.73cbc0f",
       "result": {
@@ -11150,7 +11150,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/dd651de8f984bc2bc5d791eceedf16e70cca0cdc.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/dd651de8f984bc2bc5d791eceedf16e70cca0cdc.html"
       },
       "assertedBy": "https://github.com/dequelabs/axe-core/releases/tag/4.4.3-canary.73cbc0f",
       "result": {
@@ -11174,7 +11174,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/1b172036f8e219ef9b6f591d7f5df26e4ba11327.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/1b172036f8e219ef9b6f591d7f5df26e4ba11327.html"
       },
       "assertedBy": "https://github.com/dequelabs/axe-core/releases/tag/4.4.3-canary.73cbc0f",
       "result": {
@@ -11198,7 +11198,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/c3ed1c920db04a7b13d043fae5766694cf50d561.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/c3ed1c920db04a7b13d043fae5766694cf50d561.html"
       },
       "assertedBy": "https://github.com/dequelabs/axe-core/releases/tag/4.4.3-canary.73cbc0f",
       "result": {
@@ -11222,7 +11222,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/4147da2dd50e2326a7985207296cfcd0ba57a1ee.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/4147da2dd50e2326a7985207296cfcd0ba57a1ee.html"
       },
       "assertedBy": "https://github.com/dequelabs/axe-core/releases/tag/4.4.3-canary.73cbc0f",
       "result": {
@@ -11246,7 +11246,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/8bd420282f8209ce236004c61bc4bbd728afceb7.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/8bd420282f8209ce236004c61bc4bbd728afceb7.html"
       },
       "assertedBy": "https://github.com/dequelabs/axe-core/releases/tag/4.4.3-canary.73cbc0f",
       "result": {
@@ -11270,7 +11270,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/0f4a37cd30bd688d1a8ebbb915b2c70a4bf0272c.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/0f4a37cd30bd688d1a8ebbb915b2c70a4bf0272c.html"
       },
       "assertedBy": "https://github.com/dequelabs/axe-core/releases/tag/4.4.3-canary.73cbc0f",
       "result": {
@@ -11294,7 +11294,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/dcb42362e4cd8108444dd64c8538ef0523de0aa7.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/dcb42362e4cd8108444dd64c8538ef0523de0aa7.html"
       },
       "assertedBy": "https://github.com/dequelabs/axe-core/releases/tag/4.4.3-canary.73cbc0f",
       "result": {
@@ -11318,31 +11318,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/a2525d7f2db0db246df0a702416606c56085a17a.html"
-      },
-      "assertedBy": "https://github.com/dequelabs/axe-core/releases/tag/4.4.3-canary.73cbc0f",
-      "result": {
-        "@type": "TestResult",
-        "outcome": "earl:inapplicable"
-      },
-      "test": {
-        "@type": "TestCase",
-        "title": "object-alt",
-        "@id": "https://dequeuniversity.com/rules/axe/4.4/object-alt?application=axeAPI",
-        "isPartOf": [
-          "WCAG2:non-text-content"
-        ]
-      }
-    },
-    {
-      "@type": "Assertion",
-      "mode": "earl:automatic",
-      "subject": {
-        "@type": [
-          "earl:TestSubject",
-          "sch:WebPage"
-        ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/f6b0a52f8bb37ab0a8b290237add5be669a28b2f.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/a2525d7f2db0db246df0a702416606c56085a17a.html"
       },
       "assertedBy": "https://github.com/dequelabs/axe-core/releases/tag/4.4.3-canary.73cbc0f",
       "result": {
@@ -11366,7 +11342,31 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/fd273c99d6129f0972ffdbe529b2b1cfa1116cf0.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/f6b0a52f8bb37ab0a8b290237add5be669a28b2f.html"
+      },
+      "assertedBy": "https://github.com/dequelabs/axe-core/releases/tag/4.4.3-canary.73cbc0f",
+      "result": {
+        "@type": "TestResult",
+        "outcome": "earl:failed"
+      },
+      "test": {
+        "@type": "TestCase",
+        "title": "object-alt",
+        "@id": "https://dequeuniversity.com/rules/axe/4.4/object-alt?application=axeAPI",
+        "isPartOf": [
+          "WCAG2:non-text-content"
+        ]
+      }
+    },
+    {
+      "@type": "Assertion",
+      "mode": "earl:automatic",
+      "subject": {
+        "@type": [
+          "earl:TestSubject",
+          "sch:WebPage"
+        ],
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/fd273c99d6129f0972ffdbe529b2b1cfa1116cf0.html"
       },
       "assertedBy": "https://github.com/dequelabs/axe-core/releases/tag/4.4.3-canary.73cbc0f",
       "result": {
@@ -11390,7 +11390,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/84c10ba8bc5570e900a60a2e29b319e68fc093da.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/84c10ba8bc5570e900a60a2e29b319e68fc093da.html"
       },
       "assertedBy": "https://github.com/dequelabs/axe-core/releases/tag/4.4.3-canary.73cbc0f",
       "result": {
@@ -11414,7 +11414,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/52ac3fd2be278ede2bb32987a32673c6d5ee5edb.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/52ac3fd2be278ede2bb32987a32673c6d5ee5edb.html"
       },
       "assertedBy": "https://github.com/dequelabs/axe-core/releases/tag/4.4.3-canary.73cbc0f",
       "result": {
@@ -11438,7 +11438,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/90927d72c81e9a9b27034a1a99adbab46c86e196.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/90927d72c81e9a9b27034a1a99adbab46c86e196.html"
       },
       "assertedBy": "https://github.com/dequelabs/axe-core/releases/tag/4.4.3-canary.73cbc0f",
       "result": {
@@ -11462,7 +11462,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/511c1b1647549d8af305f68253dda6d4161bd9bc.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/511c1b1647549d8af305f68253dda6d4161bd9bc.html"
       },
       "assertedBy": "https://github.com/dequelabs/axe-core/releases/tag/4.4.3-canary.73cbc0f",
       "result": {
@@ -11486,7 +11486,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/852f57fb1f11a0a58d288746c14d52ce8f8dd97a.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/852f57fb1f11a0a58d288746c14d52ce8f8dd97a.html"
       },
       "assertedBy": "https://github.com/dequelabs/axe-core/releases/tag/4.4.3-canary.73cbc0f",
       "result": {
@@ -11510,7 +11510,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/fac8b25d43d0bbea83f5fe8c5fddf1b3566ac1fb.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/fac8b25d43d0bbea83f5fe8c5fddf1b3566ac1fb.html"
       },
       "assertedBy": "https://github.com/dequelabs/axe-core/releases/tag/4.4.3-canary.73cbc0f",
       "result": {
@@ -11534,7 +11534,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/25b2c00b86322f15c0cbb376b58b342fff916f62.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/25b2c00b86322f15c0cbb376b58b342fff916f62.html"
       },
       "assertedBy": "https://github.com/dequelabs/axe-core/releases/tag/4.4.3-canary.73cbc0f",
       "result": {

--- a/reports/axe-devtools-combined.json
+++ b/reports/axe-devtools-combined.json
@@ -13740,7 +13740,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/2c4e13b6606b88bbe10bfffbe4b6f4e6d373c4a7.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/2c4e13b6606b88bbe10bfffbe4b6f4e6d373c4a7.html"
       },
       "result": {
         "@type": "TestResult",
@@ -13763,7 +13763,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/dd651de8f984bc2bc5d791eceedf16e70cca0cdc.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/dd651de8f984bc2bc5d791eceedf16e70cca0cdc.html"
       },
       "result": {
         "@type": "TestResult",
@@ -13786,7 +13786,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/1b172036f8e219ef9b6f591d7f5df26e4ba11327.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/1b172036f8e219ef9b6f591d7f5df26e4ba11327.html"
       },
       "result": {
         "@type": "TestResult",
@@ -13809,7 +13809,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/c3ed1c920db04a7b13d043fae5766694cf50d561.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/c3ed1c920db04a7b13d043fae5766694cf50d561.html"
       },
       "result": {
         "@type": "TestResult",
@@ -13832,7 +13832,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/4147da2dd50e2326a7985207296cfcd0ba57a1ee.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/4147da2dd50e2326a7985207296cfcd0ba57a1ee.html"
       },
       "result": {
         "@type": "TestResult",
@@ -13855,7 +13855,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/8bd420282f8209ce236004c61bc4bbd728afceb7.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/8bd420282f8209ce236004c61bc4bbd728afceb7.html"
       },
       "result": {
         "@type": "TestResult",
@@ -13878,7 +13878,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/0f4a37cd30bd688d1a8ebbb915b2c70a4bf0272c.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/0f4a37cd30bd688d1a8ebbb915b2c70a4bf0272c.html"
       },
       "result": {
         "@type": "TestResult",
@@ -13901,7 +13901,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/dcb42362e4cd8108444dd64c8538ef0523de0aa7.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/dcb42362e4cd8108444dd64c8538ef0523de0aa7.html"
       },
       "result": {
         "@type": "TestResult",
@@ -13924,30 +13924,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/a2525d7f2db0db246df0a702416606c56085a17a.html"
-      },
-      "result": {
-        "@type": "TestResult",
-        "outcome": "earl:inapplicable"
-      },
-      "test": {
-        "@type": "TestCase",
-        "title": "object-alt",
-        "@id": "https://dequeuniversity.com/rules/axe/4.4/object-alt?application=axeAPI",
-        "isPartOf": [
-          "WCAG2:non-text-content"
-        ]
-      }
-    },
-    {
-      "@type": "Assertion",
-      "mode": "earl:automatic",
-      "subject": {
-        "@type": [
-          "earl:TestSubject",
-          "sch:WebPage"
-        ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/f6b0a52f8bb37ab0a8b290237add5be669a28b2f.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/a2525d7f2db0db246df0a702416606c56085a17a.html"
       },
       "result": {
         "@type": "TestResult",
@@ -13970,7 +13947,30 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/fd273c99d6129f0972ffdbe529b2b1cfa1116cf0.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/f6b0a52f8bb37ab0a8b290237add5be669a28b2f.html"
+      },
+      "result": {
+        "@type": "TestResult",
+        "outcome": "earl:failed"
+      },
+      "test": {
+        "@type": "TestCase",
+        "title": "object-alt",
+        "@id": "https://dequeuniversity.com/rules/axe/4.4/object-alt?application=axeAPI",
+        "isPartOf": [
+          "WCAG2:non-text-content"
+        ]
+      }
+    },
+    {
+      "@type": "Assertion",
+      "mode": "earl:automatic",
+      "subject": {
+        "@type": [
+          "earl:TestSubject",
+          "sch:WebPage"
+        ],
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/fd273c99d6129f0972ffdbe529b2b1cfa1116cf0.html"
       },
       "result": {
         "@type": "TestResult",
@@ -13993,7 +13993,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/84c10ba8bc5570e900a60a2e29b319e68fc093da.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/84c10ba8bc5570e900a60a2e29b319e68fc093da.html"
       },
       "result": {
         "@type": "TestResult",
@@ -14016,7 +14016,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/52ac3fd2be278ede2bb32987a32673c6d5ee5edb.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/52ac3fd2be278ede2bb32987a32673c6d5ee5edb.html"
       },
       "result": {
         "@type": "TestResult",
@@ -14039,7 +14039,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/90927d72c81e9a9b27034a1a99adbab46c86e196.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/90927d72c81e9a9b27034a1a99adbab46c86e196.html"
       },
       "result": {
         "@type": "TestResult",
@@ -14062,7 +14062,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/511c1b1647549d8af305f68253dda6d4161bd9bc.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/511c1b1647549d8af305f68253dda6d4161bd9bc.html"
       },
       "result": {
         "@type": "TestResult",
@@ -14085,7 +14085,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/852f57fb1f11a0a58d288746c14d52ce8f8dd97a.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/852f57fb1f11a0a58d288746c14d52ce8f8dd97a.html"
       },
       "result": {
         "@type": "TestResult",
@@ -14108,7 +14108,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/fac8b25d43d0bbea83f5fe8c5fddf1b3566ac1fb.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/fac8b25d43d0bbea83f5fe8c5fddf1b3566ac1fb.html"
       },
       "result": {
         "@type": "TestResult",
@@ -14131,7 +14131,7 @@
           "earl:TestSubject",
           "sch:WebPage"
         ],
-        "source": "https://wai-wcag-act-rules.netlify.app/content-assets/wcag-act-rules/testcases/8fc3b6/25b2c00b86322f15c0cbb376b58b342fff916f62.html"
+        "source": "https://www.w3.org/WAI/content-assets/wcag-act-rules/testcases/8fc3b6/25b2c00b86322f15c0cbb376b58b342fff916f62.html"
       },
       "result": {
         "@type": "TestResult",

--- a/reports/axe-devtools-mapping.json
+++ b/reports/axe-devtools-mapping.json
@@ -3,8 +3,8 @@
   "name": "Axe DevTools Pro",
   "version": "latest",
   "approvedRules": {
-    "complete": 18,
-    "partial": 3,
+    "complete": 19,
+    "partial": 2,
     "minimal": 0,
     "inconsistent": 1,
     "untested": 0
@@ -5823,7 +5823,7 @@
       "procedureNames": [
         "object-alt"
       ],
-      "consistency": "partial",
+      "consistency": "complete",
       "accessibilityRequirements": {
         "correct": true,
         "expected": [
@@ -5834,7 +5834,7 @@
         ]
       },
       "coverage": {
-        "covered": 17,
+        "covered": 18,
         "untested": 0,
         "cantTell": 0,
         "testCaseTotal": 18
@@ -5970,7 +5970,7 @@
             {
               "procedureName": "object-alt",
               "outcomes": [
-                "inapplicable"
+                "failed"
               ]
             }
           ]

--- a/src/axeRunTestCase.ts
+++ b/src/axeRunTestCase.ts
@@ -23,10 +23,15 @@ export const axeRunTestCase: ToolRunner = async (
   testCase: TestCase
 ): Promise<EarlReport | void> => {
   const { ruleSuccessCriterion: tags = [], ruleId } = testCase;
-  const url = (testCase?.url || "").replace(
-    'https://www.w3.org/WAI/',
-    'https://wai-wcag-act-rules.netlify.app/'
-  )
+  let url = testCase?.url;
+  // Workaround for Netlify issue where the Object rule won't load the images
+  if (testCase.ruleId !== '8fc3b6') {
+    url = (testCase?.url || "").replace(
+      'https://www.w3.org/WAI/',
+      'https://wai-wcag-act-rules.netlify.app/'
+    )
+  }
+
   // check if running axe should be ignored
   const extn = getFileExtension(url);
   const env = { url, version: axe.version };
@@ -38,6 +43,9 @@ export const axeRunTestCase: ToolRunner = async (
 
   // Get the page and make sure it loads correctly
   await page.goto(url, { waitUntil: "networkidle0" });
+  if (testCase.ruleId === '8fc3b6') {
+    await new Promise(r => setTimeout(r, 200))
+  }
 
   // if given page is of type `html`, ensure it loaded
   if (extn === `html`) {


### PR DESCRIPTION
Running against Netlify has the problem that external resources that need to be loaded in can't be, because the URLs aren't correct. For most rules its fine that images aren't loading, but for the object-alt rule this matters. So I've hard-coded an exception for that rule in so that it runs as it should.

For context, we're using Netlify URLs because those are up to a week ahead of what's on the W3C site. That ensures our implementation data is never lags behind what's no the W3C site. We just can't do that for object-alt because of the URL issues.