### PR TITLE
fix: push act axe reports to the `act-reports-axe` instead of `main`

### DIFF
--- a/.github/workflows/data-update.yml
+++ b/.github/workflows/data-update.yml
@@ -17,6 +17,7 @@ jobs:
             **/node_modules
             !**/node_modules/.cache
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+      - run: git checkout act-reports-axe
       ## Make sure we have the latest version of axe-core
       - run: yarn upgrade axe-core@next
       - run: yarn cleanup:core
@@ -28,4 +29,4 @@ jobs:
       - run: git add reports/. package.json yarn.lock
       # Commit if there's anything staged
       - run: git diff-index --quiet HEAD || git commit -m "Daily update of axe ACT reports" --no-verify
-      - run: git push origin HEAD:act-reports-axe
+      - run: git push

--- a/.github/workflows/data-update.yml
+++ b/.github/workflows/data-update.yml
@@ -28,4 +28,4 @@ jobs:
       - run: git add reports/. package.json yarn.lock
       # Commit if there's anything staged
       - run: git diff-index --quiet HEAD || git commit -m "Daily update of axe ACT reports" --no-verify
-      - run: git push
+      - run: git push origin HEAD:act-reports-axe

--- a/.github/workflows/data-update.yml
+++ b/.github/workflows/data-update.yml
@@ -17,6 +17,7 @@ jobs:
             **/node_modules
             !**/node_modules/.cache
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+      - run: git fetch
       - run: git checkout act-reports-axe
       ## Make sure we have the latest version of axe-core
       - run: yarn upgrade axe-core@next


### PR DESCRIPTION
Push act axe reports to the `act-reports-axe` instead of `main`, we can't directly push to main https://github.com/dequelabs/act-reports-axe/actions/runs/15918571858/job/44900666456